### PR TITLE
Use APPD_WSGI_MODULE to side-step imp.load_source deadlock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,4 @@ Without:
 2. On a different shell, run `make test` to start bombarding it with [Apache
    Bench](https://httpd.apache.org/docs/2.2/programs/ab.html). Note that the
    test finishes successfully.
-3. Kill the server, switch to the `appd` branch and repeat the steps. Note that
-   the UWSGI server hangs completely
-
-
-Observations
-============
-
-1. When using `processes = 1` and `threads = 1` in the
-   `uwsgi/vassals-default.ini` file, both branches behave just fine
-2. When introducing concurrency with more processes and threads (for instance,
-   `processes = 2` and `threads = 50`), the `appd` branch can't handle it
-3. The issue can be triggered to happen even more often by making UWSGI reload
-   the workers more often under concurrent traffic. This can be achieved by
-   adding `max-requests = 5` and `max-requests-delta = 1` to the
-   `uwsgi/vassals-default.ini`
-4. When working with 1 process only and more than 1 thread but no forced
-   reloading, the `appd` branch can survive `make test` if the worker is loaded
-   before hand by issuing a single request (i.e. `curl http://127.0.0.1:8000/`)
+3. Kill the server, switch to the `appd` branch and repeat the steps.

--- a/uwsgi/foo.ini
+++ b/uwsgi/foo.ini
@@ -6,6 +6,10 @@ home = %(base_dir)/venv
 chdir = %(base_dir)/foo
 http = :8000
 
+# Prior to AppDynamics 4.2.2, the above could deadlock uwsgi during worker
+# restart due to a bug in imp.load_source:
+#env = APPD_WSGI_SCRIPT_ALIAS=%(base_dir)/foo/foo/wsgi.py
+
 env = APPD_CONFIG_FILE=%(base_dir)/foo.cfg
-env = APPD_WSGI_SCRIPT_ALIAS=%(base_dir)/foo/foo/wsgi.py
+env = APPD_WSGI_MODULE=foo.foo.wsgi:application
 module = appdynamics.scripts.wsgi


### PR DESCRIPTION
The `APPD_WSGI_SCRIPT_ALIAS` setting uses `imp.load_source` which deadlocks in uwsgi internals. This switches the configuration of this example to use `APPD_WSGI_MODULE`, side-stepping the deadlock. The fix for the `APPD_WSGI_SCRIPT_ALIAS` setting will be released in a forthcoming patch of the AppDynamics Python agent.

The Observations section has been removed since the observations were strictly about the deadlock. We encourage you to run the test again and report your observations for this benchmark.
